### PR TITLE
Refactor CardManageEmotion section

### DIFF
--- a/src/components/card/style.css
+++ b/src/components/card/style.css
@@ -1,7 +1,16 @@
 .card_main {
-  background-color: rgb(235, 197, 136) !important;
   border-radius: 10px !important;
   overflow: hidden;
+  box-shadow: 3px 5px 20px -10px rgba(8,8,8,0.75);
+-webkit-box-shadow: 3px 5px 20px -10px rgba(8,8,8,0.75);
+-moz-box-shadow: 3px 5px 20px -10px rgba(8,8,8,0.75);
 }
+
+.card-img-top {
+  height: 300px;
+  object-fit: cover;
+  object-position: center;
+}
+
 
 /*  */

--- a/src/pages/user/index.jsx
+++ b/src/pages/user/index.jsx
@@ -81,7 +81,7 @@ function User() {
         accept="image/png, image/jpeg, image/jpg"
       ></input>
 
-      <div className="d-flex flex-wrap justify-content-around">
+      <div className="d-flex flex-wrap justify-content-center gap-4">
         {emotions.map((v, i) => (
           <CardManageEmotion key={i} manageEmotions={v}></CardManageEmotion>
         ))}


### PR DESCRIPTION
# Description

This PR improves the appearance of the grid of emotion cards with the following changes:

1. Unify size of images on the header of the card.
2. Removal of orange background.
3. Addition of slight shadow under the card.
4. Applying center alignment and flex gap to the cards container.

### Before
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/28660051/185919330-2e41373a-d336-4663-a4c0-fac794e40d9c.png">

### After
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/28660051/185919401-fa25de13-4b43-4b03-b7bf-edb556424cc6.png">
