### PR TITLE
Remove spacing rules in card component and space in parent

### DIFF
--- a/src/components/card/index.jsx
+++ b/src/components/card/index.jsx
@@ -7,7 +7,7 @@ function CardManageEmotion({ manageEmotions }) {
   console.log("TIPO DE DATO", manageEmotions);
   return (
     <>
-      <Card className="mt-5 mb-5 card_main" style={{ width: "27rem" }}>
+      <Card className="card_main" style={{ width: "27rem" }}>
         <Card.Img
           variant="top"
           src="https://cdn-prod.medicalnewstoday.com/content/images/articles/320/320562/a-sad-woman-looking-out-of-the-window.jpg"
@@ -24,7 +24,7 @@ function CardManageEmotion({ manageEmotions }) {
         </Card.Body>
       </Card>
 
-      <Card className="mt-5 mb-5 card_main" style={{ width: "27rem" }}>
+      <Card className="card_main" style={{ width: "27rem" }}>
         <Card.Img
           variant="top"
           src="https://images.theconversation.com/files/304963/original/file-20191203-66982-1rzdvz4.jpg?ixlib=rb-1.1.0&rect=31%2C71%2C5330%2C2665&q=45&auto=format&w=1356&h=668&fit=crop"
@@ -40,7 +40,7 @@ function CardManageEmotion({ manageEmotions }) {
         </Card.Body>
       </Card>
 
-      <Card className="mt-5 mb-5 card_main" style={{ width: "27rem" }}>
+      <Card className="card_main" style={{ width: "27rem" }}>
         <Card.Img
           variant="top"
           src="https://www.clinicaladvisor.com/wp-content/uploads/sites/11/2020/08/woman.anxiety.attack_G_1155214538-860x573.jpg"
@@ -57,7 +57,7 @@ function CardManageEmotion({ manageEmotions }) {
         </Card.Body>
       </Card>
 
-      <Card className="mt-5 mb-5 card_main" style={{ width: "27rem" }}>
+      <Card className="card_main" style={{ width: "27rem" }}>
         <Card.Img
           variant="top"
           src="https://img.freepik.com/free-photo/portrait-young-european-man-being-stupor-as-sees-his-phobia-keeps-mouth-opened-expresses-fear_273609-2967.jpg?w=2000"

--- a/src/pages/user/index.jsx
+++ b/src/pages/user/index.jsx
@@ -72,7 +72,7 @@ function User() {
   return (
     <>
       {/* <div className="d-flex flex-wrap justify-content-around"> */}
-      <div className="d-flex flex-wrap justify-content-center gap-4">
+      <div className="d-flex flex-wrap justify-content-center gap-4 py-5">
         <CardManageEmotion></CardManageEmotion>
       </div>
 


### PR DESCRIPTION
# Description

This PR improves the spacing and placement of emotion cards.

🚨 **IMPORTANT:** It is good practice to let always the parent component apply spacing and placement rules to their children instead of let the children place themselves. The reason is that the child might be used somewhere else in the application where the placement needs to be different so those rules would disturb us. Every component should only care about its content and let its parent place it in the page and space it from its siblings.

(In the following screenshots the content of the cards has been manually edited to remove text so we can give a better view of the spacing between elements. This is just a change for the screenshot, not part of the PR).

### Before
<img width="606" alt="cards-spacing-before" src="https://user-images.githubusercontent.com/28660051/187027699-7e1e05c5-72cb-484d-a6df-fe75c45156ce.png">


### After
<img width="676" alt="cards-spacing after" src="https://user-images.githubusercontent.com/28660051/187027701-c95b574d-f508-4efe-b841-66b5fceea7ac.png">
